### PR TITLE
Making fixture type name suffix configurable (defaults to "Fixture")

### DIFF
--- a/src/org/concordion/ide/eclipse/EclipseUtils.java
+++ b/src/org/concordion/ide/eclipse/EclipseUtils.java
@@ -33,7 +33,8 @@ public class EclipseUtils {
 	public static Image createImage(String imagePath) {
 		final Bundle pluginBundle = Platform.getBundle(Activator.PLUGIN_ID);
 		final Path imageFilePath = new Path(Activator.IMAGE_PATH + imagePath);
-		final URL imageFileUrl = FileLocator.find(pluginBundle, imageFilePath, Collections.emptyMap());
+		final URL imageFileUrl = FileLocator.find(
+				pluginBundle, imageFilePath, Collections.<String, String>emptyMap());
 		return ImageDescriptor.createFromURL(imageFileUrl).createImage();
 	}
 	

--- a/src/org/concordion/ide/eclipse/JdtUtils.java
+++ b/src/org/concordion/ide/eclipse/JdtUtils.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.concordion.ide.eclipse.preferences.PreferenceConstants;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -21,9 +22,10 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.preference.IPreferenceStore;
 
 /**
- * Various utility methods for simplyfied Eclipse Java
+ * Various utility methods for simplified Eclipse Java
  * Development Tools usage.
  */
 public class JdtUtils {
@@ -104,11 +106,13 @@ public class JdtUtils {
 		
 		String pkg = getPackageForFile(specFile);
 		String typeName = FileUtils.noExtensionFileName(specFile);
-		IType fixture = findTypeInProject(pkg, typeName + "Test", javaProject);
+		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+		String suffix = preferenceStore.getString(PreferenceConstants.P_FIXTURE_TEST_SUFFIX);
+		IType fixture = findTypeInProject(pkg, typeName + suffix, javaProject);
 		if (fixture == null)  {
 			fixture = findTypeInProject(pkg, typeName, javaProject);
 		}
-		
+
 		return fixture;
 	}
 
@@ -126,7 +130,7 @@ public class JdtUtils {
 	}
 
 	/** 
-	 * Returns JUNIT3 if the type has a superclass of type TestCase anwhere in the hierarchy,
+	 * Returns JUNIT3 if the type has a superclass of type TestCase anywhere in the hierarchy,
 	 * and JUNIT4 otherwise.
 	 * @param type The fixture's type
 	 * @param superTypeHierarchy Type hierarchy to search in

--- a/src/org/concordion/ide/eclipse/preferences/ConcordionPluginPreferencePage.java
+++ b/src/org/concordion/ide/eclipse/preferences/ConcordionPluginPreferencePage.java
@@ -1,8 +1,8 @@
 package org.concordion.ide.eclipse.preferences;
 
 import org.concordion.ide.eclipse.Activator;
-import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -36,7 +36,7 @@ public class ConcordionPluginPreferencePage extends FieldEditorPreferencePage im
 		addField(new MultiLineStringFieldEditor(PreferenceConstants.P_SPEC_TEMPLATE, "Specification Template:", parent));
 		addField(new MultiLineStringFieldEditor(PreferenceConstants.P_JAVA_FIXTURE_TEMPLATE, "Java Fixture Template:", parent));
 		addField(new MultiLineStringFieldEditor(PreferenceConstants.P_GROOVY_FIXTURE_TEMPLATE, "Groovy Fixture Template:", parent));
-		addField(new BooleanFieldEditor(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, "Append 'Test' suffix to fixture class name:", parent));
+		addField(new StringFieldEditor(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, "Fixture class name suffix:", parent));
 	}
 
 	@Override

--- a/src/org/concordion/ide/eclipse/preferences/PreferenceInitializer.java
+++ b/src/org/concordion/ide/eclipse/preferences/PreferenceInitializer.java
@@ -20,7 +20,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.P_JAVA_FIXTURE_TEMPLATE, javaFixtureTemplate);
 		store.setDefault(PreferenceConstants.P_GROOVY_FIXTURE_TEMPLATE, groovyFixtureTemplate);
 		store.setDefault(PreferenceConstants.P_SPEC_TEMPLATE, specTemplate);
-		store.setDefault(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, true);
+		// The default ought to be "Fixture", since it is not a test.
+		store.setDefault(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, "Fixture");
 	}
 
 }

--- a/src/org/concordion/ide/eclipse/wizards/NewSpecWizard.java
+++ b/src/org/concordion/ide/eclipse/wizards/NewSpecWizard.java
@@ -88,9 +88,9 @@ public class NewSpecWizard extends Wizard implements INewWizard {
 		final boolean isAppendTestSuffixToFixtureClass = page.isAppendTestSuffixToFixtureClass();
 		
 		// Save test suffix preference
-		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
-		preferenceStore.setValue(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, isAppendTestSuffixToFixtureClass);
-		
+		// IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+		// preferenceStore.setValue(PreferenceConstants.P_FIXTURE_TEST_SUFFIX, isAppendTestSuffixToFixtureClass);
+
 		// Append .html if the specFileName does not have a file extension
 		if (!suppliedSpecFileName.contains(".")) {
 			suppliedSpecFileName = suppliedSpecFileName + ".html";
@@ -198,7 +198,7 @@ public class NewSpecWizard extends Wizard implements INewWizard {
 	 * @param lang Language of the fixture
 	 * @return  A name such as "Spec" + "Test" + ".java"
 	 */
-	protected static String fixtureName(String specFileName, boolean isAppendTestSuffixToFixtureClass, Language lang) {
+	protected String fixtureName(String specFileName, boolean isAppendTestSuffixToFixtureClass, Language lang) {
 		if (lang == null) {
 			return null;
 		}
@@ -208,8 +208,8 @@ public class NewSpecWizard extends Wizard implements INewWizard {
 			dotPos = specFileName.length();
 		}
 		String base = specFileName.substring(0, dotPos);
-		String suffix = isAppendTestSuffixToFixtureClass ? "Test" : "";
-		return base + suffix  + lang.getFileSuffix();
+		String suffix = (isAppendTestSuffixToFixtureClass ? page.getFixtureNameSuffix() : "");
+		return base + suffix + lang.getFileSuffix();
 	}
 
 	/**

--- a/src/org/concordion/ide/eclipse/wizards/NewSpecWizardPage.java
+++ b/src/org/concordion/ide/eclipse/wizards/NewSpecWizardPage.java
@@ -1,5 +1,7 @@
 package org.concordion.ide.eclipse.wizards;
 
+import org.concordion.ide.eclipse.Activator;
+import org.concordion.ide.eclipse.preferences.PreferenceConstants;
 import org.concordion.ide.eclipse.template.FixtureTemplate.Language;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
@@ -15,6 +17,7 @@ import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogPage;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.window.Window;
@@ -116,7 +119,7 @@ public class NewSpecWizardPage extends WizardPage {
 		createButton(container, "No Fixture", SWT.RADIO);
 		javaRadio.setSelection(true);
 
-		testSuffixCheck = createButton(container, "Append 'Test' suffix to fixture class name", SWT.CHECK);
+		testSuffixCheck = createButton(container, getTestSuffixCheckButtonText(), SWT.CHECK);
 		testSuffixCheck.setSelection(initIsAddTestSuffix);
 		
 		initialize();
@@ -218,8 +221,17 @@ public class NewSpecWizardPage extends WizardPage {
 				dialogChanged();
 			}
 		});
-		
+
 		return radio;
+	}
+
+	public String getFixtureNameSuffix() {
+		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+		return preferenceStore.getString(PreferenceConstants.P_FIXTURE_TEST_SUFFIX);
+	}
+
+	private String getTestSuffixCheckButtonText() {
+		return "Append '" + getFixtureNameSuffix() + "' suffix to fixture class name";
 	}
 
 	@Override
@@ -230,6 +242,7 @@ public class NewSpecWizardPage extends WizardPage {
 			getShell().getDisplay().asyncExec(new Runnable() {
 				@Override
 				public void run() {
+					testSuffixCheck.setText(getTestSuffixCheckButtonText());
 					fileText.setFocus();
 				}
 			});


### PR DESCRIPTION
First off, thanks for making this plugin.

I wanted to suffix my fixtures differently, but couldn't do it in the current plugin. So, I made some rough changes to make the fixture suffix configurable (defaults to "Fixture").

It's not perfect, since it also affects the method proposal lookup for the fixture class (i.e. if preferences are changed *after* the fixture was created, code-assist does not find any methods, since it looks for a differently named class).

Hope this helps.